### PR TITLE
make sure content is a string

### DIFF
--- a/src/richtext.js
+++ b/src/richtext.js
@@ -66,7 +66,7 @@ function serializeLabel(element, children) {
 }
 
 function serializeSpan(content) {
-  return content.replace(/\n/g, "<br />");
+  return (content || '').replace(/\n/g, "<br />");
 }
 
 export default {


### PR DESCRIPTION
Sometimes `content` is `null` and in those cases an error is thrown. This would make it fail safe.

Would it be possible to release this after merging?